### PR TITLE
[WIP]: Add purchase and transfer fees to nameservice contract

### DIFF
--- a/nameservice/src/coin_helpers.rs
+++ b/nameservice/src/coin_helpers.rs
@@ -72,3 +72,33 @@ fn assert_sent_sufficient_coin_works() {
         Err(e) => panic!("Unexpected error: {:?}", e),
     };
 }
+
+#[test]
+fn assert_sent_sufficient_coin_handles_parse_failure() {
+    match assert_sent_sufficient_coin(&None, coin("ff", "token")) {
+        Ok(()) => panic!("Should have raised parse error"),
+        Err(Error::ContractErr { msg, .. }) => assert_eq!(msg, "Error while parsing string to u128"),
+        Err(e) => panic!("Unexpected error: {:?}", e),
+    };
+
+    let sent_coins = Some(vec![
+        coin("abcd", "smokin"),
+        coin("5", "token"),
+    ]);
+
+    match assert_sent_sufficient_coin(&sent_coins, coin("5", "token")) {
+        Ok(()) => {}
+        Err(e) => panic!("Unexpected error: {:?}", e),
+    };
+
+    let sent_coins = Some(vec![
+        coin("abcd", "smokin"),
+        coin("efg", "token"),
+    ]);
+
+    match assert_sent_sufficient_coin(&sent_coins, coin("5", "token")) {
+        Ok(()) => panic!("Should have raised parse error"),
+        Err(Error::ContractErr { msg, .. }) => assert_eq!(msg, "Insufficient funds sent"),
+        Err(e) => panic!("Unexpected error: {:?}", e),
+    };
+}

--- a/nameservice/src/coin_helpers.rs
+++ b/nameservice/src/coin_helpers.rs
@@ -1,0 +1,74 @@
+use cosmwasm::errors::{contract_err, Error, Result};
+pub use cosmwasm::types::coin as coin_vec;
+use cosmwasm::types::Coin;
+
+fn parse_u128(source: &str) -> Result<u128> {
+    match source.parse::<u128>() {
+        Ok(value) => Ok(value),
+        Err(_) => contract_err("Error while parsing string to u128"),
+    }
+}
+
+pub fn assert_sent_sufficient_coin(sent: &Option<Vec<Coin>>, required: Coin) -> Result<()> {
+    let required_amount = parse_u128(&required.amount)?;
+
+    match sent {
+        Some(coins) => {
+            if coins.iter().any(|coin| {
+                let amount = parse_u128(&coin.amount).unwrap_or(0);
+                coin.denom == required.denom && amount >= required_amount
+            }) {
+                return Ok(());
+            }
+        }
+        None => {
+            if required_amount == 0 {
+                return Ok(());
+            }
+        }
+    }
+    return contract_err("Insufficient funds sent");
+}
+
+pub fn coin(amount: &str, denom: &str) -> Coin {
+    Coin {
+        amount: amount.to_string(),
+        denom: denom.to_string(),
+    }
+}
+
+#[test]
+fn assert_sent_sufficient_coin_works() {
+    match assert_sent_sufficient_coin(&None, coin("0", "token")) {
+        Ok(()) => {}
+        Err(e) => panic!("Unexpected error: {:?}", e),
+    };
+
+    match assert_sent_sufficient_coin(&None, coin("5", "token")) {
+        Ok(()) => panic!("Should have raised insufficient funds error"),
+        Err(Error::ContractErr { msg, .. }) => assert_eq!(msg, "Insufficient funds sent"),
+        Err(e) => panic!("Unexpected error: {:?}", e),
+    };
+
+    match assert_sent_sufficient_coin(&Some(coin_vec("10", "smokin")), coin("5", "token")) {
+        Ok(()) => panic!("Should have raised insufficient funds error"),
+        Err(Error::ContractErr { msg, .. }) => assert_eq!(msg, "Insufficient funds sent"),
+        Err(e) => panic!("Unexpected error: {:?}", e),
+    };
+
+    match assert_sent_sufficient_coin(&Some(coin_vec("10", "token")), coin("5", "token")) {
+        Ok(()) => {}
+        Err(e) => panic!("Unexpected error: {:?}", e),
+    };
+
+    let sent_coins = Some(vec![
+        coin("2", "smokin"),
+        coin("5", "token"),
+        coin("1", "earth"),
+    ]);
+
+    match assert_sent_sufficient_coin(&sent_coins, coin("5", "token")) {
+        Ok(()) => {}
+        Err(e) => panic!("Unexpected error: {:?}", e),
+    };
+}

--- a/nameservice/src/coin_helpers.rs
+++ b/nameservice/src/coin_helpers.rs
@@ -9,25 +9,24 @@ fn parse_u128(source: &str) -> Result<u128> {
     }
 }
 
-pub fn assert_sent_sufficient_coin(sent: &Option<Vec<Coin>>, required: Coin) -> Result<()> {
-    let required_amount = parse_u128(&required.amount)?;
-
-    match sent {
-        Some(coins) => {
-            if coins.iter().any(|coin| {
-                let amount = parse_u128(&coin.amount).unwrap_or(0);
-                coin.denom == required.denom && amount >= required_amount
-            }) {
-                return Ok(());
+pub fn assert_sent_sufficient_coin(sent: &Option<Vec<Coin>>, required: Option<Coin>) -> Result<()> {
+    if let Some(required_coin) = required {
+        let required_amount = parse_u128(&required_coin.amount)?;
+        if required_amount > 0 {
+            if let Some(coins) = sent {
+                if coins.iter().any(|coin| {
+                    // check if a given sent coin matches denom
+                    // and has sufficient amount
+                    let amount = parse_u128(&coin.amount).unwrap_or(0);
+                    coin.denom == required_coin.denom && amount >= required_amount
+                }) {
+                    return Ok(());
+                }
             }
-        }
-        None => {
-            if required_amount == 0 {
-                return Ok(());
-            }
+            return contract_err("Insufficient funds sent");
         }
     }
-    return contract_err("Insufficient funds sent");
+    Ok(())
 }
 
 pub fn coin(amount: &str, denom: &str) -> Coin {
@@ -39,24 +38,24 @@ pub fn coin(amount: &str, denom: &str) -> Coin {
 
 #[test]
 fn assert_sent_sufficient_coin_works() {
-    match assert_sent_sufficient_coin(&None, coin("0", "token")) {
+    match assert_sent_sufficient_coin(&None, Some(coin("0", "token"))) {
         Ok(()) => {}
         Err(e) => panic!("Unexpected error: {:?}", e),
     };
 
-    match assert_sent_sufficient_coin(&None, coin("5", "token")) {
+    match assert_sent_sufficient_coin(&None, Some(coin("5", "token"))) {
         Ok(()) => panic!("Should have raised insufficient funds error"),
         Err(Error::ContractErr { msg, .. }) => assert_eq!(msg, "Insufficient funds sent"),
         Err(e) => panic!("Unexpected error: {:?}", e),
     };
 
-    match assert_sent_sufficient_coin(&Some(coin_vec("10", "smokin")), coin("5", "token")) {
+    match assert_sent_sufficient_coin(&Some(coin_vec("10", "smokin")), Some(coin("5", "token"))) {
         Ok(()) => panic!("Should have raised insufficient funds error"),
         Err(Error::ContractErr { msg, .. }) => assert_eq!(msg, "Insufficient funds sent"),
         Err(e) => panic!("Unexpected error: {:?}", e),
     };
 
-    match assert_sent_sufficient_coin(&Some(coin_vec("10", "token")), coin("5", "token")) {
+    match assert_sent_sufficient_coin(&Some(coin_vec("10", "token")), Some(coin("5", "token"))) {
         Ok(()) => {}
         Err(e) => panic!("Unexpected error: {:?}", e),
     };
@@ -67,7 +66,7 @@ fn assert_sent_sufficient_coin_works() {
         coin("1", "earth"),
     ]);
 
-    match assert_sent_sufficient_coin(&sent_coins, coin("5", "token")) {
+    match assert_sent_sufficient_coin(&sent_coins, Some(coin("5", "token"))) {
         Ok(()) => {}
         Err(e) => panic!("Unexpected error: {:?}", e),
     };
@@ -75,28 +74,24 @@ fn assert_sent_sufficient_coin_works() {
 
 #[test]
 fn assert_sent_sufficient_coin_handles_parse_failure() {
-    match assert_sent_sufficient_coin(&None, coin("ff", "token")) {
+    match assert_sent_sufficient_coin(&None, Some(coin("ff", "token"))) {
         Ok(()) => panic!("Should have raised parse error"),
-        Err(Error::ContractErr { msg, .. }) => assert_eq!(msg, "Error while parsing string to u128"),
+        Err(Error::ContractErr { msg, .. }) => {
+            assert_eq!(msg, "Error while parsing string to u128")
+        }
         Err(e) => panic!("Unexpected error: {:?}", e),
     };
 
-    let sent_coins = Some(vec![
-        coin("abcd", "smokin"),
-        coin("5", "token"),
-    ]);
+    let sent_coins = Some(vec![coin("abcd", "smokin"), coin("5", "token")]);
 
-    match assert_sent_sufficient_coin(&sent_coins, coin("5", "token")) {
+    match assert_sent_sufficient_coin(&sent_coins, Some(coin("5", "token"))) {
         Ok(()) => {}
         Err(e) => panic!("Unexpected error: {:?}", e),
     };
 
-    let sent_coins = Some(vec![
-        coin("abcd", "smokin"),
-        coin("efg", "token"),
-    ]);
+    let sent_coins = Some(vec![coin("abcd", "smokin"), coin("efg", "token")]);
 
-    match assert_sent_sufficient_coin(&sent_coins, coin("5", "token")) {
+    match assert_sent_sufficient_coin(&sent_coins, Some(coin("5", "token"))) {
         Ok(()) => panic!("Should have raised parse error"),
         Err(Error::ContractErr { msg, .. }) => assert_eq!(msg, "Insufficient funds sent"),
         Err(e) => panic!("Unexpected error: {:?}", e),

--- a/nameservice/src/contract.rs
+++ b/nameservice/src/contract.rs
@@ -1,17 +1,25 @@
-use cosmwasm::errors::{contract_err, Result, unauthorized};
+use cosmwasm::errors::{contract_err, unauthorized, Result};
 use cosmwasm::traits::{Api, Extern, Storage};
 use cosmwasm::types::{HumanAddr, Params, Response};
 
 use crate::msg::{HandleMsg, InitMsg, QueryMsg, ResolveRecordResponse};
-use crate::state::{resolver, resolver_read, NameRecord};
+use crate::state::{config, resolver, resolver_read, Config, NameRecord};
+use crate::coin_helpers::assert_sent_sufficient_coin;
 
 use cw_storage::serialize;
 
 pub fn init<S: Storage, A: Api>(
-    _deps: &mut Extern<S, A>,
+    deps: &mut Extern<S, A>,
     _params: Params,
-    _msg: InitMsg,
+    msg: InitMsg,
 ) -> Result<Response> {
+    let config_state = Config {
+        purchase_price: msg.purchase_price,
+        transfer_price: msg.transfer_price,
+    };
+
+    config(&mut deps.storage).save(&config_state)?;
+
     Ok(Response::default())
 }
 
@@ -26,13 +34,18 @@ pub fn handle<S: Storage, A: Api>(
     }
 }
 
+
 pub fn try_register<S: Storage, A: Api>(
     deps: &mut Extern<S, A>,
     params: Params,
     name: String,
 ) -> Result<Response> {
-    let key = name.as_bytes();
+    let config_state = config(&mut deps.storage).load()?;
+    if let Some(coin_required) = config_state.purchase_price {
+        assert_sent_sufficient_coin(&params.message.sent_funds, coin_required)?;
+    }
 
+    let key = name.as_bytes();
     let record = NameRecord {
         owner: params.message.signer,
     };
@@ -54,8 +67,14 @@ pub fn try_transfer<S: Storage, A: Api>(
     name: String,
     to: HumanAddr,
 ) -> Result<Response> {
+    let config_state = config(&mut deps.storage).load()?;
+    if let Some(coin_required) = config_state.transfer_price {
+        assert_sent_sufficient_coin(&params.message.sent_funds, coin_required)?;
+    }
+
     let key = name.as_bytes();
     let new_owner = deps.api.canonical_address(&to)?;
+
 
     resolver(&mut deps.storage).update(key, &|mut record| {
         if params.message.signer != record.owner {
@@ -83,158 +102,4 @@ fn query_resolver<S: Storage, A: Api>(deps: &Extern<S, A>, name: String) -> Resu
     let resp = ResolveRecordResponse { address };
 
     serialize(&resp)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use cosmwasm::errors::Error;
-    use cosmwasm::mock::{dependencies, mock_params, MockApi, MockStorage};
-    use cosmwasm::types::coin;
-
-    use cw_storage::deserialize;
-
-    fn assert_name_owner(deps: &mut Extern<MockStorage, MockApi>, name: &str, owner: &str) {
-        let res = query(
-            &deps,
-            QueryMsg::ResolveRecord {
-                name: name.to_string(),
-            },
-        )
-        .unwrap();
-
-        let value: ResolveRecordResponse = deserialize(&res).unwrap();
-        assert_eq!(HumanAddr::from(owner), value.address);
-    }
-
-    fn mock_init_and_alice_registers_name(mut deps: &mut Extern<MockStorage, MockApi>) {
-        let msg = InitMsg {};
-        let params = mock_params(&deps.api, "creator", &coin("2", "token"), &[]);
-        let _res = init(&mut deps, params, msg).unwrap();
-
-        // anyone can register an available name
-        let params = mock_params(&deps.api, "alice_key", &coin("2", "token"), &[]);
-        let msg = HandleMsg::Register {
-            name: "alice".to_string(),
-        };
-        let _res =
-            handle(&mut deps, params, msg).expect("contract successfully handles Register message");
-    }
-
-    #[test]
-    fn proper_initialization() {
-        let mut deps = dependencies(20);
-
-        let msg = InitMsg {};
-        let params = mock_params(&deps.api, "creator", &coin("1000", "earth"), &[]);
-
-        // we can just call .unwrap() to assert this was a success
-        let res = init(&mut deps, params, msg).unwrap();
-        assert_eq!(0, res.messages.len());
-    }
-
-    #[test]
-    fn register_available_name_and_query_works() {
-        let mut deps = dependencies(20);
-        mock_init_and_alice_registers_name(&mut deps);
-
-        // querying for name resolves to correct address
-        assert_name_owner(&mut deps, "alice", "alice_key");
-    }
-
-    #[test]
-    fn fails_on_register_already_taken_name() {
-        let mut deps = dependencies(20);
-        mock_init_and_alice_registers_name(&mut deps);
-
-        // bob can't register the same name
-        let params = mock_params(&deps.api, "bob_key", &coin("2", "token"), &[]);
-        let msg = HandleMsg::Register {
-            name: "alice".to_string(),
-        };
-        let res = handle(&mut deps, params, msg);
-
-        match res {
-            Ok(_) => panic!("Must return error"),
-            Err(Error::ContractErr { msg, .. }) => assert_eq!(msg, "Name is already taken"),
-            Err(_) => panic!("Unknown error"),
-        }
-        // alice can't register the same name again
-        let params = mock_params(&deps.api, "alice_key", &coin("2", "token"), &[]);
-        let msg = HandleMsg::Register {
-            name: "alice".to_string(),
-        };
-        let res = handle(&mut deps, params, msg);
-
-        match res {
-            Ok(_) => panic!("Must return error"),
-            Err(Error::ContractErr { msg, .. }) => assert_eq!(msg, "Name is already taken"),
-            Err(e) => panic!("Unexpected error: {:?}", e),
-        }
-    }
-
-    #[test]
-    fn transfer_works() {
-        let mut deps = dependencies(20);
-        mock_init_and_alice_registers_name(&mut deps);
-
-        // alice can transfer her name successfully to bob
-        let params = mock_params(&deps.api, "alice_key", &coin("2", "token"), &[]);
-        let msg = HandleMsg::Transfer {
-            name: "alice".to_string(),
-            to: HumanAddr::from("bob_key"),
-        };
-
-        let _res =
-            handle(&mut deps, params, msg).expect("contract successfully handles Transfer message");
-        // querying for name resolves to correct address (bob_key)
-        assert_name_owner(&mut deps, "alice", "bob_key");
-    }
-
-    #[test]
-    fn fails_on_transfer_from_nonowner() {
-        let mut deps = dependencies(20);
-        mock_init_and_alice_registers_name(&mut deps);
-
-        // alice can transfer her name successfully to bob
-        let params = mock_params(&deps.api, "frank_key", &coin("2", "token"), &[]);
-        let msg = HandleMsg::Transfer {
-            name: "alice".to_string(),
-            to: HumanAddr::from("bob_key"),
-        };
-
-        let res = handle(&mut deps, params, msg);
-
-        match res {
-            Ok(_) => panic!("Must return error"),
-            Err(Error::Unauthorized { .. }) => {}
-            Err(e) => panic!("Unexpected error: {:?}", e),
-        }
-
-        // querying for name resolves to correct address (alice_key)
-        assert_name_owner(&mut deps, "alice", "alice_key");
-    }
-
-    #[test]
-    fn fails_on_query_unregistered_name() {
-        let mut deps = dependencies(20);
-
-        let msg = InitMsg {};
-        let params = mock_params(&deps.api, "creator", &coin("2", "token"), &[]);
-        let _res = init(&mut deps, params, msg).unwrap();
-
-        // querying for unregistered name results in NotFound error
-        let res = query(
-            &deps,
-            QueryMsg::ResolveRecord {
-                name: "alice".to_string(),
-            },
-        );
-
-        match res {
-            Ok(_) => panic!("Must return error"),
-            Err(Error::NotFound { kind, .. }) => assert_eq!(kind, "NameRecord"),
-            Err(e) => panic!("Unexpected error: {:?}", e),
-        }
-    }
 }

--- a/nameservice/src/lib.rs
+++ b/nameservice/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod contract;
 pub mod msg;
 pub mod state;
-mod coin_helpers;
+pub mod coin_helpers;
 
 /** Below we expose wasm exports * **/
 #[cfg(target_arch = "wasm32")]

--- a/nameservice/src/lib.rs
+++ b/nameservice/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod contract;
 pub mod msg;
 pub mod state;
+mod coin_helpers;
 
 /** Below we expose wasm exports * **/
 #[cfg(target_arch = "wasm32")]
@@ -41,3 +42,7 @@ mod wasm {
         )
     }
 }
+
+
+#[cfg(test)]
+mod tests;

--- a/nameservice/src/msg.rs
+++ b/nameservice/src/msg.rs
@@ -1,11 +1,14 @@
-use cosmwasm::types::HumanAddr;
+use cosmwasm::types::{HumanAddr, Coin};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use named_type::NamedType;
 use named_type_derive::NamedType;
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct InitMsg {}
+pub struct InitMsg {
+    pub purchase_price: Option<Coin>,
+    pub transfer_price: Option<Coin>
+}
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "lowercase")]

--- a/nameservice/src/state.rs
+++ b/nameservice/src/state.rs
@@ -4,11 +4,21 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use cosmwasm::traits::Storage;
-use cosmwasm::types::CanonicalAddr;
-use cw_storage::{bucket, bucket_read, Bucket, ReadonlyBucket};
+use cosmwasm::types::{CanonicalAddr, Coin};
+use cw_storage::{bucket, bucket_read, singleton, Bucket, ReadonlyBucket, Singleton};
 
 pub static NAME_RESOLVER_KEY: &[u8] = b"nameresolver";
 pub static CONFIG_KEY: &[u8] = b"config";
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema, NamedType)]
+pub struct Config {
+    pub purchase_price: Option<Coin>,
+    pub transfer_price: Option<Coin>,
+}
+
+pub fn config<S: Storage>(storage: &mut S) -> Singleton<S, Config> {
+    singleton(storage, CONFIG_KEY)
+}
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema, NamedType)]
 pub struct NameRecord {

--- a/nameservice/src/tests.rs
+++ b/nameservice/src/tests.rs
@@ -1,0 +1,317 @@
+use cosmwasm::errors::Error;
+use cosmwasm::mock::{dependencies, mock_params, MockApi, MockStorage};
+use cosmwasm::traits::Extern;
+use cosmwasm::types::{Coin, HumanAddr};
+
+use cw_storage::deserialize;
+
+use crate::contract::{handle, init, query};
+use crate::msg::{HandleMsg, InitMsg, QueryMsg, ResolveRecordResponse};
+use crate::state::{config, Config};
+use crate::coin_helpers::{coin, coin_vec};
+
+fn assert_name_owner(deps: &mut Extern<MockStorage, MockApi>, name: &str, owner: &str) {
+    let res = query(
+        &deps,
+        QueryMsg::ResolveRecord {
+            name: name.to_string(),
+        },
+    )
+    .unwrap();
+
+    let value: ResolveRecordResponse = deserialize(&res).unwrap();
+    assert_eq!(HumanAddr::from(owner), value.address);
+}
+
+fn mock_init_with_fees(
+    mut deps: &mut Extern<MockStorage, MockApi>,
+    purchase_price: Coin,
+    transfer_price: Coin,
+) {
+    let msg = InitMsg {
+        purchase_price: Some(purchase_price),
+        transfer_price: Some(transfer_price),
+    };
+
+    let params = mock_params(&deps.api, "creator", &coin_vec("2", "token"), &[]);
+    let _res = init(&mut deps, params, msg).expect("contract successfully handles InitMsg");
+}
+
+fn mock_init_no_fees(mut deps: &mut Extern<MockStorage, MockApi>) {
+    let msg = InitMsg {
+        purchase_price: None,
+        transfer_price: None,
+    };
+
+    let params = mock_params(&deps.api, "creator", &coin_vec("2", "token"), &[]);
+    let _res = init(&mut deps, params, msg).expect("contract successfully handles InitMsg");
+}
+
+fn mock_alice_registers_name(mut deps: &mut Extern<MockStorage, MockApi>, sent: &[Coin]) {
+    // alice can register an available name
+    let params = mock_params(&deps.api, "alice_key", sent, &[]);
+    let msg = HandleMsg::Register {
+        name: "alice".to_string(),
+    };
+    let _res =
+        handle(&mut deps, params, msg).expect("contract successfully handles Register message");
+}
+
+#[test]
+fn proper_init_no_fees() {
+    let mut deps = dependencies(20);
+
+    mock_init_no_fees(&mut deps);
+
+    let config_state = config(&mut deps.storage)
+        .load()
+        .expect("can load config from storage");
+
+    assert_eq!(
+        config_state,
+        Config {
+            purchase_price: None,
+            transfer_price: None
+        }
+    );
+}
+
+#[test]
+fn proper_init_with_fees() {
+    let mut deps = dependencies(20);
+
+    mock_init_with_fees(&mut deps, coin("2", "token"), coin("2", "token"));
+
+    let config_state = config(&mut deps.storage)
+        .load()
+        .expect("can load config from storage");
+
+    assert_eq!(
+        config_state,
+        Config {
+            purchase_price: Some(coin("2", "token")),
+            transfer_price: Some(coin("2", "token")),
+        }
+    );
+}
+
+#[test]
+fn register_available_name_and_query_works() {
+    let mut deps = dependencies(20);
+    mock_init_no_fees(&mut deps);
+    mock_alice_registers_name(&mut deps, &[]);
+
+    // querying for name resolves to correct address
+    assert_name_owner(&mut deps, "alice", "alice_key");
+}
+
+#[test]
+fn register_available_name_and_query_works_with_fees() {
+    let mut deps = dependencies(20);
+    mock_init_with_fees(&mut deps, coin("2", "token"), coin("2", "token"));
+    mock_alice_registers_name(&mut deps, &coin_vec("2", "token"));
+
+    // anyone can register an available name with more fees than needed
+    let params = mock_params(&deps.api, "bob_key", &coin_vec("5", "token"), &[]);
+    let msg = HandleMsg::Register {
+        name: "bob".to_string(),
+    };
+
+    let _res =
+        handle(&mut deps, params, msg).expect("contract successfully handles Register message");
+
+    // querying for name resolves to correct address
+    assert_name_owner(&mut deps, "alice", "alice_key");
+    assert_name_owner(&mut deps, "bob", "bob_key");
+}
+
+#[test]
+fn fails_on_register_already_taken_name() {
+    let mut deps = dependencies(20);
+    mock_init_no_fees(&mut deps);
+    mock_alice_registers_name(&mut deps, &[]);
+
+    // bob can't register the same name
+    let params = mock_params(&deps.api, "bob_key", &coin_vec("2", "token"), &[]);
+    let msg = HandleMsg::Register {
+        name: "alice".to_string(),
+    };
+    let res = handle(&mut deps, params, msg);
+
+    match res {
+        Ok(_) => panic!("Must return error"),
+        Err(Error::ContractErr { msg, .. }) => assert_eq!(msg, "Name is already taken"),
+        Err(_) => panic!("Unknown error"),
+    }
+    // alice can't register the same name again
+    let params = mock_params(&deps.api, "alice_key", &coin_vec("2", "token"), &[]);
+    let msg = HandleMsg::Register {
+        name: "alice".to_string(),
+    };
+    let res = handle(&mut deps, params, msg);
+
+    match res {
+        Ok(_) => panic!("Must return error"),
+        Err(Error::ContractErr { msg, .. }) => assert_eq!(msg, "Name is already taken"),
+        Err(e) => panic!("Unexpected error: {:?}", e),
+    }
+}
+
+#[test]
+fn fails_on_register_insufficient_fees() {
+    let mut deps = dependencies(20);
+    mock_init_with_fees(&mut deps, coin("2", "token"), coin("2", "token"));
+
+    // anyone can register an available name with sufficient fees
+    let params = mock_params(&deps.api, "alice_key", &[], &[]);
+    let msg = HandleMsg::Register {
+        name: "alice".to_string(),
+    };
+
+    let res = handle(&mut deps, params, msg);
+
+    match res {
+        Ok(_) => panic!("register call should fail with insufficient fees"),
+        Err(Error::ContractErr { msg, .. }) => assert_eq!(msg, "Insufficient funds sent"),
+        Err(e) => panic!("Unexpected error: {:?}", e),
+    }
+}
+
+#[test]
+fn fails_on_register_wrong_fee_denom() {
+    let mut deps = dependencies(20);
+    mock_init_with_fees(&mut deps, coin("2", "token"), coin("2", "token"));
+
+    // anyone can register an available name with sufficient fees
+    let params = mock_params(&deps.api, "alice_key", &coin_vec("2", "earth"), &[]);
+    let msg = HandleMsg::Register {
+        name: "alice".to_string(),
+    };
+
+    let res = handle(&mut deps, params, msg);
+
+    match res {
+        Ok(_) => panic!("register call should fail with insufficient fees"),
+        Err(Error::ContractErr { msg, .. }) => assert_eq!(msg, "Insufficient funds sent"),
+        Err(e) => panic!("Unexpected error: {:?}", e),
+    }
+}
+
+#[test]
+fn transfer_works() {
+    let mut deps = dependencies(20);
+    mock_init_no_fees(&mut deps);
+    mock_alice_registers_name(&mut deps, &[]);
+
+    // alice can transfer her name successfully to bob
+    let params = mock_params(&deps.api, "alice_key", &[], &[]);
+    let msg = HandleMsg::Transfer {
+        name: "alice".to_string(),
+        to: HumanAddr::from("bob_key"),
+    };
+
+    let _res =
+        handle(&mut deps, params, msg).expect("contract successfully handles Transfer message");
+    // querying for name resolves to correct address (bob_key)
+    assert_name_owner(&mut deps, "alice", "bob_key");
+}
+
+#[test]
+fn transfer_works_with_fees() {
+    let mut deps = dependencies(20);
+    mock_init_with_fees(&mut deps, coin("2", "token"), coin("2", "token"));
+    mock_alice_registers_name(&mut deps, &coin_vec("2", "token"));
+
+    // alice can transfer her name successfully to bob
+    let params = mock_params(
+        &deps.api,
+        "alice_key",
+        &vec![coin("1", "earth"), coin("2", "token")],
+        &[],
+    );
+    let msg = HandleMsg::Transfer {
+        name: "alice".to_string(),
+        to: HumanAddr::from("bob_key"),
+    };
+
+    let _res =
+        handle(&mut deps, params, msg).expect("contract successfully handles Transfer message");
+    // querying for name resolves to correct address (bob_key)
+    assert_name_owner(&mut deps, "alice", "bob_key");
+}
+
+#[test]
+fn fails_on_transfer_from_nonowner() {
+    let mut deps = dependencies(20);
+    mock_init_no_fees(&mut deps);
+    mock_alice_registers_name(&mut deps, &[]);
+
+    // alice can transfer her name successfully to bob
+    let params = mock_params(&deps.api, "frank_key", &coin_vec("2", "token"), &[]);
+    let msg = HandleMsg::Transfer {
+        name: "alice".to_string(),
+        to: HumanAddr::from("bob_key"),
+    };
+
+    let res = handle(&mut deps, params, msg);
+
+    match res {
+        Ok(_) => panic!("Must return error"),
+        Err(Error::Unauthorized { .. }) => {}
+        Err(e) => panic!("Unexpected error: {:?}", e),
+    }
+
+    // querying for name resolves to correct address (alice_key)
+    assert_name_owner(&mut deps, "alice", "alice_key");
+}
+
+#[test]
+fn fails_on_transfer_insufficient_fees() {
+    let mut deps = dependencies(20);
+    mock_init_with_fees(&mut deps, coin("2", "token"), coin("5", "token"));
+    mock_alice_registers_name(&mut deps, &coin_vec("2", "token"));
+
+    // alice can transfer her name successfully to bob
+    let params = mock_params(
+        &deps.api,
+        "alice_key",
+        &vec![coin("1", "earth"), coin("2", "token")],
+        &[],
+    );
+    let msg = HandleMsg::Transfer {
+        name: "alice".to_string(),
+        to: HumanAddr::from("bob_key"),
+    };
+
+    let res = handle(&mut deps, params, msg);
+
+    match res {
+        Ok(_) => panic!("register call should fail with insufficient fees"),
+        Err(Error::ContractErr { msg, .. }) => assert_eq!(msg, "Insufficient funds sent"),
+        Err(e) => panic!("Unexpected error: {:?}", e),
+    }
+
+    // querying for name resolves to correct address (bob_key)
+    assert_name_owner(&mut deps, "alice", "alice_key");
+}
+
+#[test]
+fn fails_on_query_unregistered_name() {
+    let mut deps = dependencies(20);
+
+    mock_init_no_fees(&mut deps);
+
+    // querying for unregistered name results in NotFound error
+    let res = query(
+        &deps,
+        QueryMsg::ResolveRecord {
+            name: "alice".to_string(),
+        },
+    );
+
+    match res {
+        Ok(_) => panic!("Must return error"),
+        Err(Error::NotFound { kind, .. }) => assert_eq!(kind, "NameRecord"),
+        Err(e) => panic!("Unexpected error: {:?}", e),
+    }
+}


### PR DESCRIPTION
First attempt at adding purchase & transfer fees to nameservice contract.

If all of these look good, i'll go ahead and clean up the integration tests (currently the integration tests have not been updated at all).

I wasn't exactly sure what logic we wanted in fee checking for a few edge case:
- if a string coin value is not parseable to u128 (currently this only result in parse error if the required coin is unparseable, otherwise it returns Insufficient funds error)
- if a required coin value is "0" (currently this will be treated the same as if there was no required coin value set, any amount of sent funds will be valid)

The `coin_helpers.rs` file has some tests which illustrate most of the desired behavior of `assert_sent_sufficient_coin()`.

Any feedback on new contract behavior, helpers, or test coverage is welcome.

I wanted to add the Config state to the examples/schema.rs, but realized that the schema alone wasn't sufficient for exposing an API. Any code trying to interface with raw state would also need to know the prefix of the key, and serialization of the key in the storage layer. Or is it simply expected that someone can gather this by reading the source code?

If we have a standardized way we want to provide this information, I could see us adding a few metadata keys at the beginning of each JSON schema stating a type of schema (Message, State, Response), and what the storage prefix is if it's a state schema.