### PR TITLE
Fix cargo caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - v4-cargo-cache-{{ arch }}-{{ checksum "Cargo.lock" }}
+            - cargo-cache-v2-{{ checksum "Cargo.lock" }}
       - run:
           name: Add wasm32 target
           command: rustup target add wasm32-unknown-unknown
@@ -55,13 +55,8 @@ jobs:
       - save_cache:
           paths:
             - /usr/local/cargo/registry
-            - target/debug/.fingerprint
-            - target/debug/build
-            - target/debug/deps
-            - target/wasm32-unknown-unknown/release/.fingerprint
-            - target/wasm32-unknown-unknown/release/build
-            - target/wasm32-unknown-unknown/release/deps
-          key: v4-cargo-cache-{{ arch }}-{{ checksum "Cargo.lock" }}
+            - target
+          key: cargo-cache-v2-{{ checksum "Cargo.lock" }}
   escrow:
     docker:
       - image: rust:1.38
@@ -74,7 +69,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - v4-cargo-cache-{{ arch }}-{{ checksum "Cargo.lock" }}
+            - cargo-cache-v2-{{ checksum "Cargo.lock" }}
       - run:
           name: Add wasm32 target
           command: rustup target add wasm32-unknown-unknown
@@ -109,13 +104,8 @@ jobs:
       - save_cache:
           paths:
             - /usr/local/cargo/registry
-            - target/debug/.fingerprint
-            - target/debug/build
-            - target/debug/deps
-            - target/wasm32-unknown-unknown/release/.fingerprint
-            - target/wasm32-unknown-unknown/release/build
-            - target/wasm32-unknown-unknown/release/deps
-          key: v4-cargo-cache-{{ arch }}-{{ checksum "Cargo.lock" }}
+            - target
+          key: cargo-cache-v2-{{ checksum "Cargo.lock" }}
   nameservice:
     docker:
       - image: rust:1.38
@@ -128,7 +118,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - v4-cargo-cache-{{ arch }}-{{ checksum "Cargo.lock" }}
+            - cargo-cache-v2-{{ checksum "Cargo.lock" }}
       - run:
           name: Add wasm32 target
           command: rustup target add wasm32-unknown-unknown
@@ -163,10 +153,5 @@ jobs:
       - save_cache:
           paths:
             - /usr/local/cargo/registry
-            - target/debug/.fingerprint
-            - target/debug/build
-            - target/debug/deps
-            - target/wasm32-unknown-unknown/release/.fingerprint
-            - target/wasm32-unknown-unknown/release/build
-            - target/wasm32-unknown-unknown/release/deps
-          key: v4-cargo-cache-{{ arch }}-{{ checksum "Cargo.lock" }}
+            - target
+          key: cargo-cache-v2-{{ checksum "Cargo.lock" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ workflows:
 jobs:
   erc20:
     docker:
-      - image: rust:1.38
+      - image: rust:1.38.0
     working_directory: ~/project/erc20
     steps:
       - checkout:
@@ -20,7 +20,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargo-cache-v2-{{ checksum "Cargo.lock" }}
+            - cargo-cache-v2-rust:1.38.0-{{ checksum "Cargo.lock" }}
       - run:
           name: Add wasm32 target
           command: rustup target add wasm32-unknown-unknown
@@ -56,10 +56,10 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargo-cache-v2-{{ checksum "Cargo.lock" }}
+          key: cargo-cache-v2-rust:1.38.0-{{ checksum "Cargo.lock" }}
   escrow:
     docker:
-      - image: rust:1.38
+      - image: rust:1.38.0
     working_directory: ~/project/escrow
     steps:
       - checkout:
@@ -69,7 +69,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargo-cache-v2-{{ checksum "Cargo.lock" }}
+            - cargo-cache-v2-rust:1.38.0-{{ checksum "Cargo.lock" }}
       - run:
           name: Add wasm32 target
           command: rustup target add wasm32-unknown-unknown
@@ -105,10 +105,10 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargo-cache-v2-{{ checksum "Cargo.lock" }}
+          key: cargo-cache-v2-rust:1.38.0-{{ checksum "Cargo.lock" }}
   nameservice:
     docker:
-      - image: rust:1.38
+      - image: rust:1.38.0
     working_directory: ~/project/nameservice
     steps:
       - checkout:
@@ -118,7 +118,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - restore_cache:
           keys:
-            - cargo-cache-v2-{{ checksum "Cargo.lock" }}
+            - cargo-cache-v2-rust:1.38.0-{{ checksum "Cargo.lock" }}
       - run:
           name: Add wasm32 target
           command: rustup target add wasm32-unknown-unknown
@@ -154,4 +154,4 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargo-cache-v2-{{ checksum "Cargo.lock" }}
+          key: cargo-cache-v2-rust:1.38.0-{{ checksum "Cargo.lock" }}


### PR DESCRIPTION
Cache the whole local ./target folder. The wasm build writes a lot of output to ./target/release.