### PR TITLE
update examples to use msg.rs

### DIFF
--- a/erc20/examples/schema.rs
+++ b/erc20/examples/schema.rs
@@ -4,9 +4,8 @@ use std::path::PathBuf;
 
 use schemars::{schema::RootSchema, schema_for};
 
-use cw_erc20::contract::{
-    AllowanceResponse, BalanceResponse, Constants, HandleMsg, InitMsg, QueryMsg,
-};
+use cw_erc20::contract::{AllowanceResponse, BalanceResponse, Constants};
+use cw_erc20::msg::{HandleMsg, InitMsg, QueryMsg};
 
 fn main() {
     let mut pwd = current_dir().unwrap();

--- a/erc20/examples/schema.rs
+++ b/erc20/examples/schema.rs
@@ -4,8 +4,8 @@ use std::path::PathBuf;
 
 use schemars::{schema::RootSchema, schema_for};
 
-use cw_erc20::contract::{AllowanceResponse, BalanceResponse, Constants};
-use cw_erc20::msg::{HandleMsg, InitMsg, QueryMsg};
+use cw_erc20::contract::Constants;
+use cw_erc20::msg::{AllowanceResponse, BalanceResponse, HandleMsg, InitMsg, QueryMsg};
 
 fn main() {
     let mut pwd = current_dir().unwrap();

--- a/erc20/src/contract.rs
+++ b/erc20/src/contract.rs
@@ -4,21 +4,11 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::convert::TryInto;
 
-use crate::msg::{HandleMsg, InitMsg, QueryMsg};
+use crate::msg::{AllowanceResponse, BalanceResponse, HandleMsg, InitMsg, QueryMsg};
 use cosmwasm::errors::{contract_err, dyn_contract_err, Result};
 use cosmwasm::traits::{Api, Extern, ReadonlyStorage, Storage};
 use cosmwasm::types::{CanonicalAddr, HumanAddr, Params, Response};
 use cw_storage::{serialize, PrefixedStorage, ReadonlyPrefixedStorage};
-
-#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, NamedType)]
-pub struct BalanceResponse {
-    pub balance: String,
-}
-
-#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, NamedType)]
-pub struct AllowanceResponse {
-    pub allowance: String,
-}
 
 #[derive(Serialize, Debug, Deserialize, Clone, PartialEq, JsonSchema, NamedType)]
 pub struct Constants {

--- a/erc20/src/contract.rs
+++ b/erc20/src/contract.rs
@@ -4,54 +4,11 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::convert::TryInto;
 
+use crate::msg::{HandleMsg, InitMsg, QueryMsg};
 use cosmwasm::errors::{contract_err, dyn_contract_err, Result};
 use cosmwasm::traits::{Api, Extern, ReadonlyStorage, Storage};
 use cosmwasm::types::{CanonicalAddr, HumanAddr, Params, Response};
 use cw_storage::{serialize, PrefixedStorage, ReadonlyPrefixedStorage};
-
-#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema)]
-pub struct InitialBalance {
-    pub address: HumanAddr,
-    pub amount: String,
-}
-
-#[derive(Serialize, Deserialize, JsonSchema)]
-pub struct InitMsg {
-    pub name: String,
-    pub symbol: String,
-    pub decimals: u8,
-    pub initial_balances: Vec<InitialBalance>,
-}
-
-#[derive(Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "lowercase")]
-pub enum HandleMsg {
-    Approve {
-        spender: HumanAddr,
-        amount: String,
-    },
-    Transfer {
-        recipient: HumanAddr,
-        amount: String,
-    },
-    TransferFrom {
-        owner: HumanAddr,
-        recipient: HumanAddr,
-        amount: String,
-    },
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-#[serde(rename_all = "lowercase")]
-pub enum QueryMsg {
-    Balance {
-        address: HumanAddr,
-    },
-    Allowance {
-        owner: HumanAddr,
-        spender: HumanAddr,
-    },
-}
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, NamedType)]
 pub struct BalanceResponse {

--- a/erc20/src/lib.rs
+++ b/erc20/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod contract;
+pub mod msg;
 
 #[cfg(test)]
 mod tests;

--- a/erc20/src/msg.rs
+++ b/erc20/src/msg.rs
@@ -5,44 +5,44 @@ use cosmwasm::types::HumanAddr;
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema)]
 pub struct InitialBalance {
-  pub address: HumanAddr,
-  pub amount: String,
+    pub address: HumanAddr,
+    pub amount: String,
 }
 
 #[derive(Serialize, Deserialize, JsonSchema)]
 pub struct InitMsg {
-  pub name: String,
-  pub symbol: String,
-  pub decimals: u8,
-  pub initial_balances: Vec<InitialBalance>,
+    pub name: String,
+    pub symbol: String,
+    pub decimals: u8,
+    pub initial_balances: Vec<InitialBalance>,
 }
 
 #[derive(Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum HandleMsg {
-  Approve {
-    spender: HumanAddr,
-    amount: String,
-  },
-  Transfer {
-    recipient: HumanAddr,
-    amount: String,
-  },
-  TransferFrom {
-    owner: HumanAddr,
-    recipient: HumanAddr,
-    amount: String,
-  },
+    Approve {
+        spender: HumanAddr,
+        amount: String,
+    },
+    Transfer {
+        recipient: HumanAddr,
+        amount: String,
+    },
+    TransferFrom {
+        owner: HumanAddr,
+        recipient: HumanAddr,
+        amount: String,
+    },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum QueryMsg {
-  Balance {
-    address: HumanAddr,
-  },
-  Allowance {
-    owner: HumanAddr,
-    spender: HumanAddr,
-  },
+    Balance {
+        address: HumanAddr,
+    },
+    Allowance {
+        owner: HumanAddr,
+        spender: HumanAddr,
+    },
 }

--- a/erc20/src/msg.rs
+++ b/erc20/src/msg.rs
@@ -1,0 +1,48 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use cosmwasm::types::HumanAddr;
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema)]
+pub struct InitialBalance {
+  pub address: HumanAddr,
+  pub amount: String,
+}
+
+#[derive(Serialize, Deserialize, JsonSchema)]
+pub struct InitMsg {
+  pub name: String,
+  pub symbol: String,
+  pub decimals: u8,
+  pub initial_balances: Vec<InitialBalance>,
+}
+
+#[derive(Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum HandleMsg {
+  Approve {
+    spender: HumanAddr,
+    amount: String,
+  },
+  Transfer {
+    recipient: HumanAddr,
+    amount: String,
+  },
+  TransferFrom {
+    owner: HumanAddr,
+    recipient: HumanAddr,
+    amount: String,
+  },
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum QueryMsg {
+  Balance {
+    address: HumanAddr,
+  },
+  Allowance {
+    owner: HumanAddr,
+    spender: HumanAddr,
+  },
+}

--- a/erc20/src/msg.rs
+++ b/erc20/src/msg.rs
@@ -1,3 +1,5 @@
+use named_type::NamedType;
+use named_type_derive::NamedType;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -45,4 +47,14 @@ pub enum QueryMsg {
         owner: HumanAddr,
         spender: HumanAddr,
     },
+}
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, NamedType)]
+pub struct BalanceResponse {
+    pub balance: String,
+}
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, NamedType)]
+pub struct AllowanceResponse {
+    pub allowance: String,
 }

--- a/erc20/src/tests.rs
+++ b/erc20/src/tests.rs
@@ -6,9 +6,10 @@ use cosmwasm::types::{HumanAddr, Params};
 use cw_storage::ReadonlyPrefixedStorage;
 
 use crate::contract::{
-    bytes_to_u128, handle, init, query, read_u128, Constants, HandleMsg, InitMsg, InitialBalance,
-    QueryMsg, KEY_CONSTANTS, KEY_TOTAL_SUPPLY, PREFIX_ALLOWANCES, PREFIX_BALANCES, PREFIX_CONFIG,
+    bytes_to_u128, handle, init, query, read_u128, Constants, KEY_CONSTANTS, KEY_TOTAL_SUPPLY,
+    PREFIX_ALLOWANCES, PREFIX_BALANCES, PREFIX_CONFIG,
 };
+use crate::msg::{HandleMsg, InitMsg, InitialBalance, QueryMsg};
 
 static CANONICAL_LENGTH: usize = 20;
 

--- a/erc20/tests/integration.rs
+++ b/erc20/tests/integration.rs
@@ -6,9 +6,10 @@ use cosmwasm_vm::testing::{handle, init, mock_instance, query};
 use cw_storage::ReadonlyPrefixedStorage;
 
 use cw_erc20::contract::{
-    bytes_to_u128, read_u128, Constants, HandleMsg, InitMsg, InitialBalance, QueryMsg,
-    KEY_CONSTANTS, KEY_TOTAL_SUPPLY, PREFIX_ALLOWANCES, PREFIX_BALANCES, PREFIX_CONFIG,
+    bytes_to_u128, read_u128, Constants, KEY_CONSTANTS, KEY_TOTAL_SUPPLY, PREFIX_ALLOWANCES,
+    PREFIX_BALANCES, PREFIX_CONFIG,
 };
+use cw_erc20::msg::{HandleMsg, InitMsg, InitialBalance, QueryMsg};
 
 static WASM: &[u8] = include_bytes!("../target/wasm32-unknown-unknown/release/cw_erc20.wasm");
 

--- a/escrow/examples/schema.rs
+++ b/escrow/examples/schema.rs
@@ -4,7 +4,8 @@ use std::path::PathBuf;
 
 use schemars::{schema::RootSchema, schema_for};
 
-use cw_escrow::contract::{HandleMsg, InitMsg, QueryMsg, State};
+use cw_escrow::contract::State;
+use cw_escrow::msg::{HandleMsg, InitMsg, QueryMsg};
 
 fn main() {
     let mut pwd = current_dir().unwrap();

--- a/escrow/src/contract.rs
+++ b/escrow/src/contract.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use crate::msg::{HandleMsg, InitMsg, QueryMsg};
 use cosmwasm::errors::{contract_err, unauthorized, Result};
 use cosmwasm::traits::{Api, Extern, Storage};
-use cosmwasm::types::{CanonicalAddr, Coin, CosmosMsg, Params, Response};
+use cosmwasm::types::{CanonicalAddr, Coin, CosmosMsg, HumanAddr, Params, Response};
 use cw_storage::{singleton, Singleton};
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema, NamedType)]

--- a/escrow/src/contract.rs
+++ b/escrow/src/contract.rs
@@ -3,35 +3,11 @@ use named_type_derive::NamedType;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+use crate::msg::{HandleMsg, InitMsg, QueryMsg};
 use cosmwasm::errors::{contract_err, unauthorized, Result};
 use cosmwasm::traits::{Api, Extern, Storage};
-use cosmwasm::types::{CanonicalAddr, Coin, CosmosMsg, HumanAddr, Params, Response};
+use cosmwasm::types::{CanonicalAddr, Coin, CosmosMsg, Params, Response};
 use cw_storage::{singleton, Singleton};
-
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct InitMsg {
-    pub arbiter: HumanAddr,
-    pub recipient: HumanAddr,
-    // you can set a last time or block height the contract is valid at
-    // if *either* is non-zero and below current state, the contract is considered expired
-    // and will be returned to the original funder
-    pub end_height: i64,
-    pub end_time: i64,
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-#[serde(rename_all = "lowercase")]
-pub enum HandleMsg {
-    Approve {
-        // release some coins - if quantity is None, release all coins in balance
-        quantity: Option<Vec<Coin>>,
-    },
-    Refund {},
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-#[serde(rename_all = "lowercase")]
-pub enum QueryMsg {}
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema, NamedType)]
 pub struct State {

--- a/escrow/src/lib.rs
+++ b/escrow/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod contract;
+pub mod msg;
 
 /** Below we expose wasm exports * **/
 #[cfg(target_arch = "wasm32")]

--- a/escrow/src/msg.rs
+++ b/escrow/src/msg.rs
@@ -1,0 +1,29 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use cosmwasm::types::{Coin, HumanAddr};
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct InitMsg {
+  pub arbiter: HumanAddr,
+  pub recipient: HumanAddr,
+  // you can set a last time or block height the contract is valid at
+  // if *either* is non-zero and below current state, the contract is considered expired
+  // and will be returned to the original funder
+  pub end_height: i64,
+  pub end_time: i64,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum HandleMsg {
+  Approve {
+    // release some coins - if quantity is None, release all coins in balance
+    quantity: Option<Vec<Coin>>,
+  },
+  Refund {},
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum QueryMsg {}

--- a/escrow/src/msg.rs
+++ b/escrow/src/msg.rs
@@ -5,23 +5,23 @@ use cosmwasm::types::{Coin, HumanAddr};
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct InitMsg {
-  pub arbiter: HumanAddr,
-  pub recipient: HumanAddr,
-  // you can set a last time or block height the contract is valid at
-  // if *either* is non-zero and below current state, the contract is considered expired
-  // and will be returned to the original funder
-  pub end_height: i64,
-  pub end_time: i64,
+    pub arbiter: HumanAddr,
+    pub recipient: HumanAddr,
+    // you can set a last time or block height the contract is valid at
+    // if *either* is non-zero and below current state, the contract is considered expired
+    // and will be returned to the original funder
+    pub end_height: i64,
+    pub end_time: i64,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum HandleMsg {
-  Approve {
-    // release some coins - if quantity is None, release all coins in balance
-    quantity: Option<Vec<Coin>>,
-  },
-  Refund {},
+    Approve {
+        // release some coins - if quantity is None, release all coins in balance
+        quantity: Option<Vec<Coin>>,
+    },
+    Refund {},
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/escrow/tests/integration.rs
+++ b/escrow/tests/integration.rs
@@ -4,7 +4,8 @@ use cosmwasm::types::{coin, Coin, ContractResult, CosmosMsg, HumanAddr, Params};
 
 use cosmwasm_vm::testing::{handle, init, mock_instance};
 
-use cw_escrow::contract::{config, HandleMsg, InitMsg, State};
+use cw_escrow::contract::{config, State};
+use cw_escrow::msg::{HandleMsg, InitMsg};
 
 /**
 This integration test tries to run and call the generated wasm.


### PR DESCRIPTION
- currently in the template there is a msg dir while in some examples there is not. While this is a uber minor thing it makes it a bit nicer to have it all uniform

Signed-off-by: Marko Baricevic <marbar3778@yahoo.com>