### PR TITLE
Remove wasm-bindgen from all contracts

### DIFF
--- a/erc20/Cargo.lock
+++ b/erc20/Cargo.lock
@@ -97,11 +97,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bumpalo"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "byte-tools"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -315,7 +310,6 @@ dependencies = [
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "snafu 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -958,55 +952,6 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.55"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-macro 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.55"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bumpalo 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-shared 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.55"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-macro-support 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.55"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-backend 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-shared 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "wasm-bindgen-shared"
-version = "0.2.55"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "wasmer-clif-backend"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1166,7 +1111,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum blake3 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "46080006c1505f12f64dd2a09264b343381ed3190fa02c8005d5d662ac571c63"
 "checksum block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 "checksum block-padding 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
-"checksum bumpalo 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ad807f2fc2bf185eeb98ff3a901bd46dc5ad58163d0fa4577ba0d25674d71708"
 "checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
 "checksum c2-chacha 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb"
@@ -1271,11 +1215,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d"
-"checksum wasm-bindgen 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)" = "29ae32af33bacd663a9a28241abecf01f2be64e6a185c6139b04f18b6385c5f2"
-"checksum wasm-bindgen-backend 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)" = "1845584bd3593442dc0de6e6d9f84454a59a057722f36f005e44665d6ab19d85"
-"checksum wasm-bindgen-macro 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)" = "87fcc747e6b73c93d22c947a6334644d22cfec5abd8b66238484dc2b0aeb9fe4"
-"checksum wasm-bindgen-macro-support 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)" = "3dc4b3f2c4078c8c4a5f363b92fcf62604c5913cbd16c6ff5aaf0f74ec03f570"
-"checksum wasm-bindgen-shared 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)" = "ca0b78d6d3be8589b95d1d49cdc0794728ca734adf36d7c9f07e6459508bb53d"
 "checksum wasmer-clif-backend 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ea74b659f78bffcc2db4bd77bf27ce66907ab76728d012346b130fe384e11399"
 "checksum wasmer-clif-fork-frontend 0.52.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6d2e13201ef9ef527ad30a6bf1b08e3e024a40cf2731f393d80375dc88506207"
 "checksum wasmer-clif-fork-wasm 0.52.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a8b09302cc4fdc4efc03823cb3e1880b0fde578ba43f27ddd212811cb28c1530"

--- a/erc20/Cargo.toml
+++ b/erc20/Cargo.toml
@@ -36,8 +36,6 @@ schemars = "=0.5"
 serde = { version = "=1.0.103", default-features = false, features = ["derive"] }
 snafu = { version = "=0.5.0", default-features = false, features = ["rust_1_30"] }
 hex = "=0.4.0"
-# needed for wasm-pack build process
-wasm-bindgen = "=0.2.55"
 
 [dev-dependencies]
 cosmwasm-vm = { version = "0.7.0", default-features = false }

--- a/erc20/Cargo.toml
+++ b/erc20/Cargo.toml
@@ -7,6 +7,14 @@ edition = "2018"
 license = "Apache-2.0"
 repository = "https://github.com/confio/cosmwasm-examples"
 
+exclude = [
+  # Those files are cosmwasm-opt artifacts. You might want to commit them for convenience but they should not be part of the source code publication.
+  "contract.wasm",
+  "hash.txt",
+]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
 [lib]
 crate-type = ["cdylib", "rlib"]
 
@@ -25,9 +33,9 @@ overflow-checks = true
 default = ["cranelift"]
 # for quicker tests, cargo test --lib
 # for more explicit tests, cargo test --features=backtraces
-backtraces = [ "cosmwasm/backtraces", "cosmwasm-vm/backtraces" ]
-cranelift = [ "cosmwasm-vm/default-cranelift"]
-singlepass = [ "cosmwasm-vm/default-singlepass"]
+backtraces = ["cosmwasm/backtraces", "cosmwasm-vm/backtraces"]
+cranelift = ["cosmwasm-vm/default-cranelift"]
+singlepass = ["cosmwasm-vm/default-singlepass"]
 
 [dependencies]
 cosmwasm = { version = "0.7.0" }

--- a/erc20/Developing.md
+++ b/erc20/Developing.md
@@ -3,12 +3,12 @@
 If you have recently created a contract with this template, you probably could use some
 help on how to build and test the contract, as well as prepare it for production. This
 file attempts to provide a brief overview, assuming you have installed a recent
-version of rust already (eg. 1.38+).
+version of Rust already (eg. 1.40+).
 
 ## Prerequisites
 
-Before starting, make sure you have [rustup](https://rustup.rs/) along with a recent `rustc` and `cargo`
-version installed. Currently, we are testing on 1.38+.
+Before starting, make sure you have [rustup](https://rustup.rs/) along with a
+recent `rustc` and `cargo` version installed. Currently, we are testing on 1.40+.
 
 And you need to have the `wasm32-unknown-unknown` target installed as well.
 
@@ -103,10 +103,10 @@ produce an extremely small build output in a consistent manner. The suggest way
 to run it is this:
 
 ```sh
-docker run --rm -v $(pwd):/code \
-  --mount type=volume,source=$(basename $(pwd))_cache,target=/code/target \
+docker run --rm -v "$(pwd)":/code \
+  --mount type=volume,source=$(basename "$(pwd)")_cache,target=/code/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  confio/cosmwasm-opt:0.6.0
+  confio/cosmwasm-opt:0.7.2
 ```
 
 We must mount the contract code to `/code`. You can use a absolute path instead
@@ -140,4 +140,3 @@ static WASM: &[u8] = include_bytes!("../contract.wasm");
 Note that this is the same (deterministic) code you will be uploading to
 a blockchain to test it out, as we need to shrink the size and produce a
 clear mapping from wasm hash back to the source code.
-

--- a/erc20/Publishing.md
+++ b/erc20/Publishing.md
@@ -1,12 +1,12 @@
 # Publishing Contracts
 
-This is a quick overview of how to publish contracts in this repo, or any other
-repo.
+This is an overview of how to publish the contract's source code in this repo.
+We use Cargo's default registry [crates.io](https://crates.io/) for publishing contracts written in Rust.
 
 ## Preparation
 
 Ensure the `Cargo.toml` file in the repo is properly configured. In particular, you want to
-choose a name starting with `cw-`, which will help a lot finding cosmwasm contracts when
+choose a name starting with `cw-`, which will help a lot finding CosmWasm contracts when
 searching on crates.io. For the first publication, you will probably want version `0.1.0`.
 If you have tested this on a public net already and/or had an audit on the code,
 you can start with `1.0.0`, but that should imply some level of stability and confidence.
@@ -21,61 +21,51 @@ repository = "https://github.com/confio/cosmwasm-examples"
 
 You will also want to add a valid [SPDX license statement](https://spdx.org/licenses/),
 so others know the rules for using this crate. You can use any license you wish,
-even a commercial license, but we recommend choosing one of the following, unless you have a
-personal opinion.
+even a commercial license, but we recommend choosing one of the following, unless you have
+specific requirements.
 
 * Permissive: [`Apache-2.0`](https://spdx.org/licenses/Apache-2.0.html#licenseText) or [`MIT`](https://spdx.org/licenses/MIT.html#licenseText)
-* Free Software: [`GPL-3.0-or-later`](https://spdx.org/licenses/GPL-3.0-or-later.html#licenseText) or [`AGPL-3.0-or-later`](https://spdx.org/licenses/AGPL-3.0-or-later.html#licenseText)
+* Copyleft: [`GPL-3.0-or-later`](https://spdx.org/licenses/GPL-3.0-or-later.html#licenseText) or [`AGPL-3.0-or-later`](https://spdx.org/licenses/AGPL-3.0-or-later.html#licenseText)
 * Commercial license: `Commercial` (not sure if this works, I cannot find examples)
 
 It is also helpful to download the LICENSE text (linked to above) and store this
 in a LICENSE file in your repo. Now, you have properly configured your crate for use
 in a larger ecosystem.
 
+### Updating schema
 
-### Artifacts
-
-To allow easy use of the contract, we can publish the schema, optimized wasm code,
-as well as the expected hash. You should never take this as definitive proof
-without checking it first, but the validity of these generated files will be part
-of any review. This provides a canonical place to store them, so that reviews can be
-published against a claim. You will want the following files:
-
-* `schema/*.json`
-* `contract.wasm`
-* `hash.txt`
-
-### Generate Artifacts
-
-The following commands should allow you to generate the artifacts:
-
-`schema/*.json`:
+To allow easy use of the contract, we can publish the schema (`schema/*.json`) together
+with the source code.
 
 ```sh
-rm -rf schema
 cargo schema
-# or cargo run --example schema
 ```
 
-`contract.wasm` and `hash.txt`:
-
-```sh
-docker run --rm -v $(pwd):/code \
-  --mount type=volume,source=$(basename $(pwd))_cache,target=/code/target \
-  --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  confio/cosmwasm-opt:0.7.0
-```
-
-Ensure you check in all the artifacts, and make a git commit with the final state.
+Ensure you check in all the schema files, and make a git commit with the final state.
 This commit will be published and should be tagged. Generally, you will want to
 tag with the version (eg. `v0.1.0`), but in the `cosmwasm-examples` repo, we have
 multiple contracts and label it like `escrow-0.1.0`. Don't forget a
 `git push && git push --tags`
 
+### Note on build results
+
+Build results like Wasm bytecode or expected hash don't need to be updated since
+the don't belong to the source publication. However, they are excluded from packaging
+in `Cargo.toml` which allows you to commit them to your git repository if you like.
+
+```toml
+exclude = ["contract.wasm", "hash.txt"]
+```
+
+A single source code can be built with multiple different optimizers, so
+we should not make any strict assumptions on the tooling that will be used.
+
 ## Publishing
 
 Now that your package is properly configured and all artifacts are committed, it
 is time to share it with the world.
+Please refer to the [complete instructions for any questions](https://rurust.github.io/cargo-docs-ru/crates-io.html),
+but I will try to give a quick overview of the happy path here.
 
 ### Registry
 
@@ -103,3 +93,23 @@ Once you have published your package, people can now find it by
 But that isn't exactly the simplest way. To make things easier and help
 keep the ecosystem together, we suggest making a PR to add your package
 to the [`cawesome-wasm`](https://github.com/cosmwasm/cawesome-wasm) list.
+
+### Organizations
+
+Many times you are writing a contract not as a solo developer, but rather as
+part of an organization. You will want to allow colleagues to upload new
+versions of the contract to crates.io when you are on holiday.
+[These instructions show how]() you can set up your crate to allow multiple maintainers.
+
+You can add another owner to the crate by specifying their github user. Note, you will
+now both have complete control of the crate, and they can remove you:
+
+`cargo owner --add ethanfrey`
+
+You can also add an existing github team inside your organization:
+
+`cargo owner --add github:confio:developers`
+
+The team will allow anyone who is currently in the team to publish new versions of the crate.
+And this is automatically updated when you make changes on github. However, it will not allow
+anyone in the team to add or remove other owners.

--- a/escrow/Cargo.lock
+++ b/escrow/Cargo.lock
@@ -105,11 +105,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bumpalo"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "byte-tools"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -321,7 +316,6 @@ dependencies = [
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "snafu 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -952,55 +946,6 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.55"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-macro 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.55"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bumpalo 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-shared 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.55"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-macro-support 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.55"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-backend 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-shared 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "wasm-bindgen-shared"
-version = "0.2.55"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "wasmer-clif-backend"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1161,7 +1106,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum blake3 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "46080006c1505f12f64dd2a09264b343381ed3190fa02c8005d5d662ac571c63"
 "checksum block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 "checksum block-padding 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "6d4dc3af3ee2e12f3e5d224e5e1e3d73668abbeb69e566d361f7d5563a4fdf09"
-"checksum bumpalo 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ad807f2fc2bf185eeb98ff3a901bd46dc5ad58163d0fa4577ba0d25674d71708"
 "checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
 "checksum c2-chacha 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb"
@@ -1265,11 +1209,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d"
-"checksum wasm-bindgen 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)" = "29ae32af33bacd663a9a28241abecf01f2be64e6a185c6139b04f18b6385c5f2"
-"checksum wasm-bindgen-backend 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)" = "1845584bd3593442dc0de6e6d9f84454a59a057722f36f005e44665d6ab19d85"
-"checksum wasm-bindgen-macro 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)" = "87fcc747e6b73c93d22c947a6334644d22cfec5abd8b66238484dc2b0aeb9fe4"
-"checksum wasm-bindgen-macro-support 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)" = "3dc4b3f2c4078c8c4a5f363b92fcf62604c5913cbd16c6ff5aaf0f74ec03f570"
-"checksum wasm-bindgen-shared 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)" = "ca0b78d6d3be8589b95d1d49cdc0794728ca734adf36d7c9f07e6459508bb53d"
 "checksum wasmer-clif-backend 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ea74b659f78bffcc2db4bd77bf27ce66907ab76728d012346b130fe384e11399"
 "checksum wasmer-clif-fork-frontend 0.52.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6d2e13201ef9ef527ad30a6bf1b08e3e024a40cf2731f393d80375dc88506207"
 "checksum wasmer-clif-fork-wasm 0.52.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a8b09302cc4fdc4efc03823cb3e1880b0fde578ba43f27ddd212811cb28c1530"

--- a/escrow/Cargo.toml
+++ b/escrow/Cargo.toml
@@ -37,8 +37,6 @@ cw-storage = "0.2.0"
 schemars = "=0.5"
 serde = { version = "=1.0.103", default-features = false, features = ["derive"] }
 snafu = { version = "=0.5.0", default-features = false, features = ["rust_1_30"] }
-# needed for wasm-pack build process
-wasm-bindgen = "=0.2.55"
 
 [dev-dependencies]
 cosmwasm-vm = { version = "0.7.0", default-features = false }

--- a/escrow/Cargo.toml
+++ b/escrow/Cargo.toml
@@ -7,6 +7,12 @@ license = "Apache-2.0"
 description = "Simple CosmWasm contract for an escrow with arbiter and timeout"
 repository = "https://github.com/confio/cosmwasm-examples"
 
+exclude = [
+  # Those files are cosmwasm-opt artifacts. You might want to commit them for convenience but they should not be part of the source code publication.
+  "contract.wasm",
+  "hash.txt",
+]
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [lib]
@@ -27,9 +33,9 @@ overflow-checks = true
 default = ["cranelift"]
 # for quicker tests, cargo test --lib
 # for more explicit tests, cargo test --features=backtraces
-backtraces = [ "cosmwasm/backtraces", "cosmwasm-vm/backtraces" ]
-cranelift = [ "cosmwasm-vm/default-cranelift"]
-singlepass = [ "cosmwasm-vm/default-singlepass"]
+backtraces = ["cosmwasm/backtraces", "cosmwasm-vm/backtraces"]
+cranelift = ["cosmwasm-vm/default-cranelift"]
+singlepass = ["cosmwasm-vm/default-singlepass"]
 
 [dependencies]
 cosmwasm = "0.7.0"

--- a/escrow/Developing.md
+++ b/escrow/Developing.md
@@ -3,12 +3,12 @@
 If you have recently created a contract with this template, you probably could use some
 help on how to build and test the contract, as well as prepare it for production. This
 file attempts to provide a brief overview, assuming you have installed a recent
-version of rust already (eg. 1.38+).
+version of Rust already (eg. 1.40+).
 
 ## Prerequisites
 
-Before starting, make sure you have [rustup](https://rustup.rs/) along with a recent `rustc` and `cargo`
-version installed. Currently, we are testing on 1.38+.
+Before starting, make sure you have [rustup](https://rustup.rs/) along with a
+recent `rustc` and `cargo` version installed. Currently, we are testing on 1.40+.
 
 And you need to have the `wasm32-unknown-unknown` target installed as well.
 
@@ -103,10 +103,10 @@ produce an extremely small build output in a consistent manner. The suggest way
 to run it is this:
 
 ```sh
-docker run --rm -v $(pwd):/code \
-  --mount type=volume,source=$(basename $(pwd))_cache,target=/code/target \
+docker run --rm -v "$(pwd)":/code \
+  --mount type=volume,source=$(basename "$(pwd)")_cache,target=/code/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  confio/cosmwasm-opt:0.6.0
+  confio/cosmwasm-opt:0.7.2
 ```
 
 We must mount the contract code to `/code`. You can use a absolute path instead
@@ -140,4 +140,3 @@ static WASM: &[u8] = include_bytes!("../contract.wasm");
 Note that this is the same (deterministic) code you will be uploading to
 a blockchain to test it out, as we need to shrink the size and produce a
 clear mapping from wasm hash back to the source code.
-

--- a/escrow/Publishing.md
+++ b/escrow/Publishing.md
@@ -1,12 +1,12 @@
 # Publishing Contracts
 
-This is a quick overview of how to publish contracts in this repo, or any other
-repo.
+This is an overview of how to publish the contract's source code in this repo.
+We use Cargo's default registry [crates.io](https://crates.io/) for publishing contracts written in Rust.
 
 ## Preparation
 
 Ensure the `Cargo.toml` file in the repo is properly configured. In particular, you want to
-choose a name starting with `cw-`, which will help a lot finding cosmwasm contracts when
+choose a name starting with `cw-`, which will help a lot finding CosmWasm contracts when
 searching on crates.io. For the first publication, you will probably want version `0.1.0`.
 If you have tested this on a public net already and/or had an audit on the code,
 you can start with `1.0.0`, but that should imply some level of stability and confidence.
@@ -21,53 +21,51 @@ repository = "https://github.com/confio/cosmwasm-examples"
 
 You will also want to add a valid [SPDX license statement](https://spdx.org/licenses/),
 so others know the rules for using this crate. You can use any license you wish,
-even a commercial license, but we recommend choosing one of the following, unless you have a
-personal opinion.
+even a commercial license, but we recommend choosing one of the following, unless you have
+specific requirements.
 
 * Permissive: [`Apache-2.0`](https://spdx.org/licenses/Apache-2.0.html#licenseText) or [`MIT`](https://spdx.org/licenses/MIT.html#licenseText)
-* Free Software: [`GPL-3.0-or-later`](https://spdx.org/licenses/GPL-3.0-or-later.html#licenseText) or [`AGPL-3.0-or-later`](https://spdx.org/licenses/AGPL-3.0-or-later.html#licenseText)
+* Copyleft: [`GPL-3.0-or-later`](https://spdx.org/licenses/GPL-3.0-or-later.html#licenseText) or [`AGPL-3.0-or-later`](https://spdx.org/licenses/AGPL-3.0-or-later.html#licenseText)
 * Commercial license: `Commercial` (not sure if this works, I cannot find examples)
 
 It is also helpful to download the LICENSE text (linked to above) and store this
 in a LICENSE file in your repo. Now, you have properly configured your crate for use
 in a larger ecosystem.
 
+### Updating schema
 
-### Artifacts
-
-To allow easy use of the contract, we can publish the schema, optimized wasm code,
-as well as the expected hash. You should never take this as definitive proof
-without checking it first, but the validity of these generated files will be part
-of any review. This provides a canonical place to store them, so that reviews can be
-published against a claim. You will want the following files:
-
-* `schema/*.json`
-* `contract.wasm`
-* `hash.txt`
-
-### Generate Artifacts
-
-The following commands should allow you to generate the artifacts:
-
-`schema/*.json`, `contract.wasm`, `hash.txt`:
+To allow easy use of the contract, we can publish the schema (`schema/*.json`) together
+with the source code.
 
 ```sh
-docker run --rm -v $(pwd):/code \
-  --mount type=volume,source=$(basename $(pwd))_cache,target=/code/target \
-  --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  confio/cosmwasm-opt:0.6.1
+cargo schema
 ```
 
-Ensure you check in all the artifacts, and make a git commit with the final state.
+Ensure you check in all the schema files, and make a git commit with the final state.
 This commit will be published and should be tagged. Generally, you will want to
 tag with the version (eg. `v0.1.0`), but in the `cosmwasm-examples` repo, we have
 multiple contracts and label it like `escrow-0.1.0`. Don't forget a
 `git push && git push --tags`
 
+### Note on build results
+
+Build results like Wasm bytecode or expected hash don't need to be updated since
+the don't belong to the source publication. However, they are excluded from packaging
+in `Cargo.toml` which allows you to commit them to your git repository if you like.
+
+```toml
+exclude = ["contract.wasm", "hash.txt"]
+```
+
+A single source code can be built with multiple different optimizers, so
+we should not make any strict assumptions on the tooling that will be used.
+
 ## Publishing
 
 Now that your package is properly configured and all artifacts are committed, it
 is time to share it with the world.
+Please refer to the [complete instructions for any questions](https://rurust.github.io/cargo-docs-ru/crates-io.html),
+but I will try to give a quick overview of the happy path here.
 
 ### Registry
 
@@ -95,3 +93,23 @@ Once you have published your package, people can now find it by
 But that isn't exactly the simplest way. To make things easier and help
 keep the ecosystem together, we suggest making a PR to add your package
 to the [`cawesome-wasm`](https://github.com/cosmwasm/cawesome-wasm) list.
+
+### Organizations
+
+Many times you are writing a contract not as a solo developer, but rather as
+part of an organization. You will want to allow colleagues to upload new
+versions of the contract to crates.io when you are on holiday.
+[These instructions show how]() you can set up your crate to allow multiple maintainers.
+
+You can add another owner to the crate by specifying their github user. Note, you will
+now both have complete control of the crate, and they can remove you:
+
+`cargo owner --add ethanfrey`
+
+You can also add an existing github team inside your organization:
+
+`cargo owner --add github:confio:developers`
+
+The team will allow anyone who is currently in the team to publish new versions of the crate.
+And this is automatically updated when you make changes on github. However, it will not allow
+anyone in the team to add or remove other owners.

--- a/nameservice/Cargo.lock
+++ b/nameservice/Cargo.lock
@@ -105,11 +105,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bumpalo"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "byte-tools"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -321,7 +316,6 @@ dependencies = [
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "snafu 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -952,55 +946,6 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.55"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-macro 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.55"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bumpalo 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-shared 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.55"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-macro-support 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.55"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-backend 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-shared 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "wasm-bindgen-shared"
-version = "0.2.55"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "wasmer-clif-backend"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1161,7 +1106,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum blake3 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "46080006c1505f12f64dd2a09264b343381ed3190fa02c8005d5d662ac571c63"
 "checksum block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 "checksum block-padding 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "6d4dc3af3ee2e12f3e5d224e5e1e3d73668abbeb69e566d361f7d5563a4fdf09"
-"checksum bumpalo 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ad807f2fc2bf185eeb98ff3a901bd46dc5ad58163d0fa4577ba0d25674d71708"
 "checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
 "checksum c2-chacha 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb"
@@ -1265,11 +1209,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d"
-"checksum wasm-bindgen 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)" = "29ae32af33bacd663a9a28241abecf01f2be64e6a185c6139b04f18b6385c5f2"
-"checksum wasm-bindgen-backend 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)" = "1845584bd3593442dc0de6e6d9f84454a59a057722f36f005e44665d6ab19d85"
-"checksum wasm-bindgen-macro 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)" = "87fcc747e6b73c93d22c947a6334644d22cfec5abd8b66238484dc2b0aeb9fe4"
-"checksum wasm-bindgen-macro-support 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)" = "3dc4b3f2c4078c8c4a5f363b92fcf62604c5913cbd16c6ff5aaf0f74ec03f570"
-"checksum wasm-bindgen-shared 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)" = "ca0b78d6d3be8589b95d1d49cdc0794728ca734adf36d7c9f07e6459508bb53d"
 "checksum wasmer-clif-backend 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ea74b659f78bffcc2db4bd77bf27ce66907ab76728d012346b130fe384e11399"
 "checksum wasmer-clif-fork-frontend 0.52.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6d2e13201ef9ef527ad30a6bf1b08e3e024a40cf2731f393d80375dc88506207"
 "checksum wasmer-clif-fork-wasm 0.52.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a8b09302cc4fdc4efc03823cb3e1880b0fde578ba43f27ddd212811cb28c1530"

--- a/nameservice/Cargo.toml
+++ b/nameservice/Cargo.toml
@@ -37,8 +37,6 @@ cw-storage = "0.2.0"
 schemars = "=0.5"
 serde = { version = "=1.0.103", default-features = false, features = ["derive"] }
 snafu = { version = "=0.5.0", default-features = false, features = ["rust_1_30"] }
-# needed for wasm-pack build process
-wasm-bindgen = "=0.2.55"
 
 [dev-dependencies]
 cosmwasm-vm = { version = "0.7.0", default-features = false }

--- a/nameservice/Cargo.toml
+++ b/nameservice/Cargo.toml
@@ -7,6 +7,12 @@ edition = "2018"
 license = "Apache-2.0"
 repository = "https://github.com/confio/cosmwasm-examples"
 
+exclude = [
+  # Those files are cosmwasm-opt artifacts. You might want to commit them for convenience but they should not be part of the source code publication.
+  "contract.wasm",
+  "hash.txt",
+]
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [lib]

--- a/nameservice/Developing.md
+++ b/nameservice/Developing.md
@@ -3,12 +3,12 @@
 If you have recently created a contract with this template, you probably could use some
 help on how to build and test the contract, as well as prepare it for production. This
 file attempts to provide a brief overview, assuming you have installed a recent
-version of rust already (eg. 1.38+).
+version of Rust already (eg. 1.40+).
 
 ## Prerequisites
 
-Before starting, make sure you have [rustup](https://rustup.rs/) along with a recent `rustc` and `cargo`
-version installed. Currently, we are testing on 1.38+.
+Before starting, make sure you have [rustup](https://rustup.rs/) along with a
+recent `rustc` and `cargo` version installed. Currently, we are testing on 1.40+.
 
 And you need to have the `wasm32-unknown-unknown` target installed as well.
 
@@ -103,10 +103,10 @@ produce an extremely small build output in a consistent manner. The suggest way
 to run it is this:
 
 ```sh
-docker run --rm -v $(pwd):/code \
-  --mount type=volume,source=$(basename $(pwd))_cache,target=/code/target \
+docker run --rm -v "$(pwd)":/code \
+  --mount type=volume,source=$(basename "$(pwd)")_cache,target=/code/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  confio/cosmwasm-opt:0.7.0
+  confio/cosmwasm-opt:0.7.2
 ```
 
 We must mount the contract code to `/code`. You can use a absolute path instead
@@ -140,4 +140,3 @@ static WASM: &[u8] = include_bytes!("../contract.wasm");
 Note that this is the same (deterministic) code you will be uploading to
 a blockchain to test it out, as we need to shrink the size and produce a
 clear mapping from wasm hash back to the source code.
-

--- a/nameservice/Importing.md
+++ b/nameservice/Importing.md
@@ -59,10 +59,7 @@ cargo run --example schema
 And to generate the `contract.wasm` and `hash.txt`:
 
 ```sh
-docker run --rm -v $(pwd):/code \
-  --mount type=volume,source=$(basename $(pwd))_cache,target=/code/target \
-  --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  confio/cosmwasm-opt:0.6.1
+docker run --rm -u $(id -u):$(id -g) -v $(pwd):/code confio/cosmwasm-opt:0.4.1
 sha256sum contract.wasm > hash.txt
 ```
 

--- a/nameservice/Publishing.md
+++ b/nameservice/Publishing.md
@@ -1,12 +1,12 @@
 # Publishing Contracts
 
-This is a quick overview of how to publish contracts in this repo, or any other
-repo.
+This is an overview of how to publish the contract's source code in this repo.
+We use Cargo's default registry [crates.io](https://crates.io/) for publishing contracts written in Rust.
 
 ## Preparation
 
 Ensure the `Cargo.toml` file in the repo is properly configured. In particular, you want to
-choose a name starting with `cw-`, which will help a lot finding cosmwasm contracts when
+choose a name starting with `cw-`, which will help a lot finding CosmWasm contracts when
 searching on crates.io. For the first publication, you will probably want version `0.1.0`.
 If you have tested this on a public net already and/or had an audit on the code,
 you can start with `1.0.0`, but that should imply some level of stability and confidence.
@@ -21,46 +21,44 @@ repository = "https://github.com/confio/cosmwasm-examples"
 
 You will also want to add a valid [SPDX license statement](https://spdx.org/licenses/),
 so others know the rules for using this crate. You can use any license you wish,
-even a commercial license, but we recommend choosing one of the following, unless you have a
-personal opinion.
+even a commercial license, but we recommend choosing one of the following, unless you have
+specific requirements.
 
 * Permissive: [`Apache-2.0`](https://spdx.org/licenses/Apache-2.0.html#licenseText) or [`MIT`](https://spdx.org/licenses/MIT.html#licenseText)
-* Free Software: [`GPL-3.0-or-later`](https://spdx.org/licenses/GPL-3.0-or-later.html#licenseText) or [`AGPL-3.0-or-later`](https://spdx.org/licenses/AGPL-3.0-or-later.html#licenseText)
+* Copyleft: [`GPL-3.0-or-later`](https://spdx.org/licenses/GPL-3.0-or-later.html#licenseText) or [`AGPL-3.0-or-later`](https://spdx.org/licenses/AGPL-3.0-or-later.html#licenseText)
 * Commercial license: `Commercial` (not sure if this works, I cannot find examples)
 
 It is also helpful to download the LICENSE text (linked to above) and store this
 in a LICENSE file in your repo. Now, you have properly configured your crate for use
 in a larger ecosystem.
 
+### Updating schema
 
-### Artifacts
-
-To allow easy use of the contract, we can publish the schema, optimized wasm code,
-as well as the expected hash. You should never take this as definitive proof
-without checking it first, but the validity of these generated files will be part
-of any review. This provides a canonical place to store them, so that reviews can be
-published against a claim. You will want the following files:
-
-* `schema/*.json`
-* `contract.wasm`
-* `hash.txt`
-
-### Generate Artifacts
-
-The following commands will allow you to generate the artifacts in a determinstic manner,
-so it can easily be validate by others (please change `CONTRACT` to the name of your contract):
+To allow easy use of the contract, we can publish the schema (`schema/*.json`) together
+with the source code.
 
 ```sh
-docker run --rm -v $(pwd):/code \
-  --mount type=volume,source=nameservice_cache,target=/code/target \
-  confio/cosmwasm-opt:0.6.2
+cargo schema
 ```
 
-Ensure you check in all the artifacts, and make a git commit with the final state.
+Ensure you check in all the schema files, and make a git commit with the final state.
 This commit will be published and should be tagged. Generally, you will want to
 tag with the version (eg. `v0.1.0`), but in the `cosmwasm-examples` repo, we have
 multiple contracts and label it like `escrow-0.1.0`. Don't forget a
 `git push && git push --tags`
+
+### Note on build results
+
+Build results like Wasm bytecode or expected hash don't need to be updated since
+the don't belong to the source publication. However, they are excluded from packaging
+in `Cargo.toml` which allows you to commit them to your git repository if you like.
+
+```toml
+exclude = ["contract.wasm", "hash.txt"]
+```
+
+A single source code can be built with multiple different optimizers, so
+we should not make any strict assumptions on the tooling that will be used.
 
 ## Publishing
 


### PR DESCRIPTION
- Remove wasm-bindgen from all contracts
- Exclude contract.wasm and hash.txt from source code publication
- Update the 3 docs 1:1 from the template repo. I think all desired changes should be done there since 1:1 copy is the only way we can keep them mostly up to date if we want them in every example.